### PR TITLE
v1.0.1

### DIFF
--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -3,9 +3,6 @@ name: Publish Docker images
 on:
   release:
     types: [published]
-  push:
-    branches:
-      - dev
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -71,7 +71,7 @@ jobs:
             type=ref,event=tag
             type=raw,value=${{ github.ref_name }}-r${{ matrix.r_version }}
             type=raw,value=${{ matrix.r_version }}
-            type=raw,value=latest,enable=${{ matrix.r_version == env.LATEST_R_VERSION }}
+            type=raw,value=latest,enable=${{ matrix.r_version == env.LATEST_R_VERSION && github.ref != 'refs/heads/dev' }}
             type=raw,value=${{ matrix.r_version }}-dev,enable=${{ github.ref == 'refs/heads/dev' }}
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' && matrix.r_version == env.LATEST_R_VERSION }}
         

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -3,6 +3,9 @@ name: Publish Docker images
 on:
   release:
     types: [published]
+  push:
+    branches:
+      - dev
   workflow_dispatch:
 
 env:
@@ -72,6 +75,8 @@ jobs:
             type=raw,value=${{ github.ref_name }}-r${{ matrix.r_version }}
             type=raw,value=${{ matrix.r_version }}
             type=raw,value=latest,enable=${{ matrix.r_version == env.LATEST_R_VERSION }}
+            type=raw,value=${{ matrix.r_version }}-dev,enable=${{ github.ref == 'refs/heads/dev' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' && matrix.r_version == env.LATEST_R_VERSION }}
         
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        r_version: ["4.5"]  # Build latest only to save CI time/space
+        r_version: ["4.3", "4.4", "4.5"]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.1] - 2026-01-09
+
+### Fixed
+- Resolve R 4.3 build failure by removing `librdf0-dev`, which pulled in `libraptor2-dev` and conflicted with `libcurl4-openssl-dev`.
+
+### Changed
+- CI: PR validation workflow now builds all R matrix versions (4.3, 4.4, 4.5) to catch version-specific build issues early.
+- CI: Build workflow now publishes dev images on push to `dev` branch, tagged with `-dev` suffix (e.g., `4.5-dev`, `dev`).
+
+### Added
+- Makefile: `build-all` target to build images for R 4.3, 4.4, and 4.5 in one command.
+- Makefile: `pr-validate` target to run linters and `build-all` locally, mirroring CI PR validation.
+- Documentation updates in README and AGENTS to reflect local validation steps and removal of automated runtime tests.
 
 ## [1.0.0] - 2026-01-09
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,6 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
     libproj-dev \
     libprotobuf-dev \
     libquantlib0-dev \
-    librdf0-dev \
     librsvg2-dev \
     libsasl2-dev \
     libsecret-1-dev \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build build-4.3 build-4.4 build-4.5 up down restart logs clean lint
+.PHONY: help build build-4.3 build-4.4 build-4.5 build-all up down restart logs clean lint pr-validate
 
 # Default target
 help:
@@ -16,6 +16,8 @@ help:
 	@echo "  make build-4.3    - Build image with R 4.3"
 	@echo "  make build-4.4    - Build image with R 4.4"
 	@echo "  make build-4.5    - Build image with R 4.5"
+	@echo "  make build-all    - Build images for R 4.3, 4.4, 4.5"
+	@echo "  make pr-validate  - Run lint and build-all (mirrors CI PR build)"
 	@echo ""
 	@echo "Test commands:"
 	@echo "  make lint         - Run linters (hadolint + shellcheck)"
@@ -50,6 +52,12 @@ build-4.4:
 build-4.5:
 	docker build --platform linux/amd64 --build-arg R_VERSION=4.5 -t rstudio-local:4.5 .
 
+# Build all supported R versions
+build-all:
+	$(MAKE) build-4.3
+	$(MAKE) build-4.4
+	$(MAKE) build-4.5
+
 # Lint commands
 lint:
 	@echo "Linting Dockerfile..."
@@ -57,6 +65,11 @@ lint:
 	@echo ""
 	@echo "Linting shell scripts..."
 	@shellcheck install_quarto_latest.sh || echo "shellcheck not installed. Install with: brew install shellcheck"
+
+# Run the same steps as PR validation locally
+pr-validate:
+	$(MAKE) lint
+	$(MAKE) build-all
 
 # Cleanup
 clean:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Customized Docker images for RStudio Server with scientific computing packages, supporting multiple R versions.
 
-[![Publish Docker images](https://github.com/zatzmanm/rstudio-img/actions/workflows/build_push.yaml/badge.svg)](https://github.com/zatzmanm/rstudio-img/actions/workflows/build_push.yaml)
-[![PR Validation](https://github.com/zatzmanm/rstudio-img/actions/workflows/pr-validation.yaml/badge.svg)](https://github.com/zatzmanm/rstudio-img/actions/workflows/pr-validation.yaml)
+[![Publish Docker images](https://github.com/mjz1/rstudio-img/actions/workflows/build_push.yaml/badge.svg)](https://github.com/mjz1/rstudio-img/actions/workflows/build_push.yaml)
+[![PR Validation](https://github.com/mjz1/rstudio-img/actions/workflows/pr-validation.yaml/badge.svg)](https://github.com/mjz1/rstudio-img/actions/workflows/pr-validation.yaml)
 
 ## Docker Images
 


### PR DESCRIPTION
## [1.0.1] - 2026-01-09

### Fixed
- Resolve R 4.3 build failure by removing `librdf0-dev`, which pulled in `libraptor2-dev` and conflicted with `libcurl4-openssl-dev`.

### Changed
- CI: PR validation workflow now builds all R matrix versions (4.3, 4.4, 4.5) to catch version-specific build issues early.
- CI: Build workflow now publishes dev images on push to `dev` branch, tagged with `-dev` suffix (e.g., `4.5-dev`, `dev`).

### Added
- Makefile: `build-all` target to build images for R 4.3, 4.4, and 4.5 in one command.
- Makefile: `pr-validate` target to run linters and `build-all` locally, mirroring CI PR validation.
- Documentation updates in README and AGENTS to reflect local validation steps and removal of automated runtime tests.